### PR TITLE
fix: align formatted date distance to time zone

### DIFF
--- a/app/edit.tsx
+++ b/app/edit.tsx
@@ -22,8 +22,6 @@ export default function EditNote() {
 	const isiOS = Platform.OS === "ios"
 	const isAndroid = Platform.OS === "android"
 
-	console.log("changes: ", isEditing, isiOS, isAndroid, id)
-
 	const DeleteButton = (
 		<Pressable
 			onPress={() => {

--- a/app/edit.tsx
+++ b/app/edit.tsx
@@ -22,10 +22,12 @@ export default function EditNote() {
 	const isiOS = Platform.OS === "ios"
 	const isAndroid = Platform.OS === "android"
 
+	console.log("changes: ", isEditing, isiOS, isAndroid, id)
+
 	const DeleteButton = (
 		<Pressable
 			onPress={() => {
-				deleteNote(id)
+				id && deleteNote(id)
 				router.back()
 			}}
 			className="active:opacity-50"

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -6,7 +6,7 @@ export const notes = sqliteTable("notes", {
 	title: text("title"),
 	body: text("body"),
 	createdAt: text("created_at")
-		.default(sql`CURRENT_TIMESTAMP`)
+		.default(sql`strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`)
 		.notNull(),
 	updatedAt: text("updated_at"),
 })

--- a/drizzle/0000_past_meltdown.sql
+++ b/drizzle/0000_past_meltdown.sql
@@ -2,6 +2,6 @@ CREATE TABLE `notes` (
 	`id` integer PRIMARY KEY NOT NULL,
 	`title` text,
 	`body` text,
-	`created_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
 	`updated_at` text
 );

--- a/hooks/use-note-store.ts
+++ b/hooks/use-note-store.ts
@@ -66,7 +66,6 @@ const useEditNoteStore = create<EditNoteStore>((set, get) => ({
 			set((state) => ({ note: { ...state.note, title } })),
 		onChangeBody: (body) => set((state) => ({ note: { ...state.note, body } })),
 		saveNote: (id) => {
-			console.log("STRE LOG: ", id)
 			const { title, body } = get().note
 			if (!title && !body) return
 			db.insert(notes)

--- a/hooks/use-note-store.ts
+++ b/hooks/use-note-store.ts
@@ -54,7 +54,7 @@ type EditNoteStore = {
 	actions: {
 		onChangeTitle: (title: string) => void
 		onChangeBody: (body: string) => void
-		saveNote: (id: string) => void
+		saveNote: (id: string | undefined) => void
 		deleteNote: (id: string) => void
 	}
 }
@@ -66,6 +66,7 @@ const useEditNoteStore = create<EditNoteStore>((set, get) => ({
 			set((state) => ({ note: { ...state.note, title } })),
 		onChangeBody: (body) => set((state) => ({ note: { ...state.note, body } })),
 		saveNote: (id) => {
+			console.log("STRE LOG: ", id)
 			const { title, body } = get().note
 			if (!title && !body) return
 			db.insert(notes)


### PR DESCRIPTION
Fixes the wrong time distance that shows for any device not located in the UTC time zone.
 
Tested on iOS and Android
 
[Here's](https://sentry.io/answers/parsing-a-string-to-a-date-in-javascript/#:~:text=It%20is%20equivalent%20to%20Greenwich,%2DDDTHH%3Amm%3Ass%20.) a _slightly_ related discussion on the topic.
 
> ## Extra notes:
For context, I am at a UTC + 1 location

 ## Before

https://github.com/emmanuelchucks/drizzle-expo-sqlite/assets/66207244/f802d313-77ce-49ad-86b9-8e81d159e3d8


 ## After

https://github.com/emmanuelchucks/drizzle-expo-sqlite/assets/66207244/fa19624e-3400-46a6-89b8-e6d439792d5f

I also took the liberty of resolving the TS error in `app/edit.tsx`.

Thanks for sharing this project 🙏🏾 

