### PR TITLE
refactor(theme): adopt platform-native semantic colors via NativeWind

### DIFF
--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -1,8 +1,7 @@
 import "@/global.css";
-import { DarkTheme, DefaultTheme, ThemeProvider } from "@react-navigation/native";
 import { Link, Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
-import { Platform, Pressable, useColorScheme } from "react-native";
+import { Platform, Pressable } from "react-native";
 import { AppIcon } from "@/components/icon";
 import { DatabaseProvider } from "@/db/provider";
 
@@ -13,35 +12,31 @@ export const unstable_settings = {
 };
 
 export default function RootLayout() {
-  const colorScheme = useColorScheme();
-
   return (
-    <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
-      <DatabaseProvider>
-        <StatusBar animated style="auto" />
-        <Stack>
-          <Stack.Screen
-            name="index"
-            options={{
-              title: "Notes",
-              headerRight: () => (
-                <Link href="/edit" asChild>
-                  <Pressable className="active:opacity-70">
-                    <AppIcon name="add" size={26} color="#3B82F6" />
-                  </Pressable>
-                </Link>
-              ),
-            }}
-          />
-          <Stack.Screen
-            name="edit"
-            options={{
-              title: "Edit note",
-              presentation: Platform.OS === "ios" ? "modal" : "card",
-            }}
-          />
-        </Stack>
-      </DatabaseProvider>
-    </ThemeProvider>
+    <DatabaseProvider>
+      <StatusBar animated style="auto" />
+      <Stack>
+        <Stack.Screen
+          name="index"
+          options={{
+            title: "Notes",
+            headerRight: () => (
+              <Link href="/edit" asChild>
+                <Pressable className="active:opacity-70">
+                  <AppIcon name="add" size={26} />
+                </Pressable>
+              </Link>
+            ),
+          }}
+        />
+        <Stack.Screen
+          name="edit"
+          options={{
+            title: "Edit note",
+            presentation: Platform.OS === "ios" ? "modal" : "card",
+          }}
+        />
+      </Stack>
+    </DatabaseProvider>
   );
 }

--- a/src/app/edit.tsx
+++ b/src/app/edit.tsx
@@ -47,7 +47,7 @@ export default function EditScreen() {
           title: id ? "Edit note" : "New note",
           headerRight: () => (
             <Pressable onPress={() => void form.handleSubmit()} className="active:opacity-70">
-              <AppIcon name="save" color="#3B82F6" size={26} />
+              <AppIcon name="save" size={26} />
             </Pressable>
           ),
           headerLeft: id
@@ -65,7 +65,7 @@ export default function EditScreen() {
                   }
                   className="active:opacity-70"
                 >
-                  <AppIcon name="delete" color="#E11D48" size={24} />
+                  <AppIcon name="delete" size={24} />
                 </Pressable>
               )
             : undefined,
@@ -79,7 +79,7 @@ export default function EditScreen() {
             onChangeText={field.handleChange}
             placeholder="Title"
             style={{ lineHeight: 0 }}
-            className="bg-card text-foreground rounded-xl border border-zinc-300 p-4 text-2xl font-semibold dark:border-zinc-700"
+            className="bg-card text-foreground rounded-xl border border-border p-4 text-2xl font-semibold placeholder:text-muted"
           />
         )}
       </form.Field>
@@ -93,7 +93,7 @@ export default function EditScreen() {
             placeholder="Start writing..."
             textAlignVertical="top"
             style={{ lineHeight: 0 }}
-            className="bg-card text-foreground min-h-80 flex-1 rounded-xl border border-zinc-300 p-4 text-lg dark:border-zinc-700"
+            className="bg-card text-foreground min-h-80 flex-1 rounded-xl border border-border p-4 text-lg placeholder:text-muted"
           />
         )}
       </form.Field>

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -54,15 +54,14 @@ export default function NotesScreen() {
 
   return (
     <View className="bg-background flex-1 px-4">
-      <View className="bg-card mt-4 mb-3 flex-row items-center gap-2 rounded-xl border border-zinc-300 px-3 dark:border-zinc-700">
-        <AppIcon name="search" color="#8E8E93" size={20} />
+      <View className="bg-card mt-4 mb-3 flex-row items-center gap-2 rounded-xl border border-border px-3">
+        <AppIcon name="search" size={20} />
         <TextInput
           value={queryParam}
           onChangeText={(text) => router.setParams({ q: text || undefined })}
           placeholder="Search notes"
-          placeholderTextColor="#8E8E93"
           style={{ lineHeight: 0 }}
-          className="text-foreground flex-1 py-3 text-[16px]"
+          className="text-foreground placeholder:text-muted flex-1 py-3 text-[16px]"
         />
       </View>
 

--- a/src/global.css
+++ b/src/global.css
@@ -4,21 +4,45 @@
 @import "nativewind/theme";
 
 @theme {
-  --color-background: oklch(1 0 0);
-  --color-foreground: oklch(0.2 0 0);
-  --color-card: oklch(0.97 0.01 255);
-  --color-muted: oklch(0.65 0.02 255);
-  --color-accent: oklch(0.64 0.2 258);
-  --color-danger: oklch(0.57 0.22 27);
+  --color-background: var(--surface-background);
+  --color-foreground: var(--surface-foreground);
+  --color-card: var(--surface-card);
+  --color-muted: var(--surface-muted);
+  --color-accent: var(--surface-accent);
+  --color-danger: var(--surface-danger);
+  --color-border: var(--surface-border);
 }
 
-@media (prefers-color-scheme: dark) {
+:root {
+  --surface-background: oklch(1 0 0);
+  --surface-foreground: oklch(0.2 0 0);
+  --surface-card: oklch(0.97 0.01 255);
+  --surface-muted: oklch(0.65 0.02 255);
+  --surface-accent: oklch(0.64 0.2 258);
+  --surface-danger: oklch(0.57 0.22 27);
+  --surface-border: oklch(0.85 0.01 255);
+}
+
+@media ios {
   :root {
-    --color-background: oklch(0.17 0.01 255);
-    --color-foreground: oklch(0.97 0 0);
-    --color-card: oklch(0.24 0.01 255);
-    --color-muted: oklch(0.78 0.02 255);
-    --color-accent: oklch(0.74 0.17 258);
-    --color-danger: oklch(0.67 0.2 27);
+    --surface-background: platformColor("systemBackground");
+    --surface-foreground: platformColor("label");
+    --surface-card: platformColor("secondarySystemBackground");
+    --surface-muted: platformColor("secondaryLabel");
+    --surface-accent: platformColor("link");
+    --surface-danger: platformColor("systemRed");
+    --surface-border: platformColor("separator");
+  }
+}
+
+@media android {
+  :root {
+    --surface-background: platformColor("?attr/colorBackground");
+    --surface-foreground: platformColor("?attr/textColorPrimary");
+    --surface-card: platformColor("?attr/colorSurface", "?attr/colorBackgroundFloating");
+    --surface-muted: platformColor("?attr/textColorSecondary");
+    --surface-accent: platformColor("?attr/colorAccent", "?attr/colorPrimary");
+    --surface-danger: platformColor("?attr/colorError");
+    --surface-border: platformColor("?attr/listDivider");
   }
 }

--- a/src/lib/ui.ts
+++ b/src/lib/ui.ts
@@ -3,7 +3,7 @@ import { cn, tv } from "tailwind-variants";
 export { cn };
 
 export const noteCardStyles = tv({
-  base: "bg-card flex-1 gap-2 rounded-2xl border border-zinc-300 p-4 active:opacity-70 dark:border-zinc-700",
+  base: "bg-card flex-1 gap-2 rounded-2xl border border-border p-4 active:opacity-70",
 });
 
 export const buttonStyles = tv({


### PR DESCRIPTION
## Why
The app still used hardcoded runtime colors and manual dark/light border mappings, which made theme behavior harder to maintain and easy to drift across screens. This change centralizes color decisions in NativeWind semantic tokens backed by platform colors so UI adapts automatically with system theme.

## What changed
- Reworked src/global.css to map semantic tokens (background, foreground, card, muted, accent, danger, border) to platform-backed variables.
- Added iOS/Android platformColor mappings with a web-safe fallback.
- Removed manual navigation theme switching in src/app/_layout.tsx (no ThemeProvider + useColorScheme branch).
- Removed hardcoded icon/placeholder colors and dark/light border wrangling from screens.
- Updated shared card styles to use semantic border-border.

## Validation
- pnpm typecheck
- pnpm lint